### PR TITLE
fix: permissions is an array of permission data

### DIFF
--- a/discord_typings/interactions/commands.py
+++ b/discord_typings/interactions/commands.py
@@ -400,7 +400,7 @@ class GuildApplicationCommandPermissionData(TypedDict):
     id: Snowflake
     application_id: Snowflake
     guild_id: Snowflake
-    permissions: ApplicationCommandPermissionsData
+    permissions: List[ApplicationCommandPermissionsData]
 
 
 # https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure


### PR DESCRIPTION
Just a little fix to correctly note how `permissions` for `GuildApplicationCommandPermissionData` is an array (list) of `ApplicationCommandPermissionsData`s, not just a singular entity.

See [here in the Discord Docs](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) as a reference.