### PR TITLE
Add new `communication_disabled_until` key for `GuildMemberData` and fix type of `UserData.email`

### DIFF
--- a/discord_typings/resources/guild.py
+++ b/discord_typings/resources/guild.py
@@ -197,6 +197,7 @@ class GuildMemberData(TypedDict):
     mute: bool
     pending: NotRequired[bool]
     permissions: NotRequired[str]
+    communication_disabled_until: NotRequired[Optional[str]]
 
 
 # https://discord.com/developers/docs/resources/guild#integration-object-integration-structure

--- a/discord_typings/resources/user.py
+++ b/discord_typings/resources/user.py
@@ -24,7 +24,7 @@ class UserBase(TypedDict):
     accent_color: NotRequired[Optional[int]]
     locale: NotRequired[Locales]
     verified: NotRequired[bool]
-    email: NotRequired[Optional[bool]]
+    email: NotRequired[Optional[str]]
     flags: NotRequired[int]
     premium_type: NotRequired[UserPremiumTypes]
     public_flags: NotRequired[int]


### PR DESCRIPTION
I have noticed within the documentation of the User object, email is a string, and I am unsure if I have missed anything, but I think that it should be a string, and not a bool.
![image](https://user-images.githubusercontent.com/73362400/191014427-2a217a73-771f-4989-960b-7681e3673796.png)
