### PR TITLE
Add `stickers` key to `GuildPreviewData` and fix typo

### DIFF
--- a/discord_typings/resources/guild.py
+++ b/discord_typings/resources/guild.py
@@ -158,6 +158,7 @@ class GuildPreviewData(TypedDict):
     approximate_member_count: int
     approximate_presence_count: int
     description: Optional[str]
+    stickers: List[StickerData]
 
 
 # https://discord.com/developers/docs/resources/guild#guild-widget-object-guild-widget-structure

--- a/discord_typings/resources/voice.py
+++ b/discord_typings/resources/voice.py
@@ -27,7 +27,7 @@ class VoiceStateData(TypedDict):
     self_mute: bool
     self_stream: NotRequired[bool]
     self_video: bool
-    seppress: bool
+    suppress: bool
     request_to_speak_timestamp: Optional[str]
 
 


### PR DESCRIPTION
Discord have added stickers as part of the `GuildPreviewObject`, and I've matched that here.