### PR TITLE
Add new permission fields to ChatInputCommandData

### DIFF
--- a/discord_typings/interactions/commands.py
+++ b/discord_typings/interactions/commands.py
@@ -40,6 +40,8 @@ class ChatInputCommandData(TypedDict):
     description: str
     description_localizations: NotRequired[Optional[Dict[Locales, str]]]
     options: List[ApplicationCommandOptionData]
+    default_member_permissions: Optional[str]
+    dm_permission: NotRequired[bool]
     default_permission: NotRequired[bool]
     version: Snowflake
 

--- a/discord_typings/interactions/commands.py
+++ b/discord_typings/interactions/commands.py
@@ -55,7 +55,8 @@ class ContextMenuCommandData(TypedDict):
     name_localizations: NotRequired[Optional[Dict[Locales, str]]]
     description: str
     description_localizations: NotRequired[Optional[Dict[Locales, str]]]
-    default_permission: NotRequired[bool]
+    default_member_permissions: Optional[str]
+    dm_permission: NotRequired[bool]
     version: Snowflake
 
 
@@ -428,7 +429,8 @@ class ApplicationCommandPayload(TypedDict):
     name: str
     description: str
     options: NotRequired[List[ApplicationCommandOptionData]]
-    default_permission: NotRequired[bool]
+    default_member_permissions: Optional[str]
+    dm_permission: NotRequired[bool]
     type: NotRequired[Literal[1, 2, 3]]
 
 

--- a/discord_typings/interactions/commands.py
+++ b/discord_typings/interactions/commands.py
@@ -42,7 +42,6 @@ class ChatInputCommandData(TypedDict):
     options: List[ApplicationCommandOptionData]
     default_member_permissions: Optional[str]
     dm_permission: NotRequired[bool]
-    default_permission: NotRequired[bool]
     version: Snowflake
 
 


### PR DESCRIPTION
Two things that I am unsure of is whether Permissions are to be typed as string or if there is a class for this. The other thing is if I should remove `default_permission` as no one should use it according to the documentation.