### PR TITLE
Rename and add fields to ThreadMetadataData

### DIFF
--- a/discord_typings/gateway.py
+++ b/discord_typings/gateway.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
         IntegrationAccountData, IntegrationApplicationData,
         IntegrationExpireBehaviors, MessageData, NewsChannelData, RoleData,
         StageInstanceData, StickerData, TextChannelData, ThreadChannelData,
-        ThreadMemberData, ThreadMetadata, UnavailableGuildData, UserData,
+        ThreadMemberData, ThreadMetadataData, UnavailableGuildData, UserData,
         VoiceChannelData, VoiceStateData, WelcomeScreenData
     )
 
@@ -425,7 +425,7 @@ class ThreadCreateData(TypedDict):
     last_pin_timestamp: NotRequired[Optional[str]]
     message_count: int
     member_count: int
-    thread_metadata: ThreadMetadata
+    thread_metadata: ThreadMetadataData
     member: NotRequired[ThreadMemberData]
 
     newly_created: bool  # Extra THREAD_CREATE field

--- a/discord_typings/resources/channel.py
+++ b/discord_typings/resources/channel.py
@@ -22,7 +22,7 @@ __all__ = (
     'GuildMessageData', 'MessageData', 'UserMentionData', 'MessageTypes',
     'MessageActivityData', 'MessageActivityTypes', 'PermissionOverwriteData',
     'ThreadChannelData', 'MessageReferenceData', 'FollowedChannelData',
-    'PermissionOverwriteData', 'ThreadMetadata', 'ThreadMemberData', 'EmbedData',
+    'PermissionOverwriteData', 'ThreadMetadataData', 'ThreadMemberData', 'EmbedData',
     'EmbedThumbnailData', 'EmbedVideoData', 'EmbedImageData',
     'EmbedProviderData', 'EmbedAuthorData', 'EmbedFieldData', 'EmbedFooterData',
     'PartialAttachmentData', 'AttachmentData', 'AllowedMentionsData', 'HasMoreListThreadsData',
@@ -116,7 +116,7 @@ class ThreadChannelData(TypedDict):
     applied_tags: NotRequired[List[Snowflake]]
     message_count: int
     member_count: int
-    thread_metadata: ThreadMetadata
+    thread_metadata: ThreadMetadataData
     member: NotRequired[ThreadMemberData]
 
 
@@ -310,7 +310,7 @@ class PermissionOverwriteData(TypedDict):
 
 
 @final
-class ThreadMetadata(TypedDict):
+class ThreadMetadataData(TypedDict):
     archived: bool
     auto_archive_duration: int
     archive_timestamp: str

--- a/discord_typings/resources/channel.py
+++ b/discord_typings/resources/channel.py
@@ -316,6 +316,7 @@ class ThreadMetadataData(TypedDict):
     archive_timestamp: str
     locked: bool
     invitable: NotRequired[bool]
+    create_timestamp: NotRequired[Optional[str]]
 
 
 # https://discord.com/developers/docs/resources/channel#thread-member-object-thread-member-structure


### PR DESCRIPTION
`ThreadMetadata` breaks the rule in the README stating that objects that are generic top level payloads will end with `Data`. There are other mentions of ThreadMetadata I still need to do.