### PR TITLE
Fix `AuditLogEntryData.options` type

### DIFF
--- a/discord_typings/resources/audit_log.py
+++ b/discord_typings/resources/audit_log.py
@@ -47,7 +47,7 @@ class AuditLogEntryData(TypedDict):
     user_id: Optional[Snowflake]
     id: Snowflake
     action_type: AuditLogEvents
-    options: NotRequired[OptionalAuditLogEntryData]
+    options: NotRequired[Optional[AuditLogEntryData]]
     reason: NotRequired[str]
 
 


### PR DESCRIPTION
Optional was missing its brackets