### PR TITLE
UserBase.id is a Snowflake

### DIFF
--- a/discord_typings/resources/user.py
+++ b/discord_typings/resources/user.py
@@ -8,12 +8,13 @@ __all__ = ('UserData', 'UserPremiumTypes')
 
 if TYPE_CHECKING:
     from ..interactions import Locales
+    from ..reference import Snowflake
 
 # https://discord.com/developers/docs/resources/user#user-object-user-structure
 
 
 class UserBase(TypedDict):
-    id: str
+    id: Snowflake
     username: str
     discriminator: str
     avatar: Optional[str]


### PR DESCRIPTION
`UserBase.id` used to be `str`, which is not *entirely* correct. I've changed it to Snowflake now.