### PR TITLE
Update library following upstream docs changes

### DIFF
--- a/discord_typings/_gateway.py
+++ b/discord_typings/_gateway.py
@@ -12,9 +12,9 @@ if TYPE_CHECKING:
     # inside of strings (not annotations) for the type aliases, so we have to
     # disable the check.
     from ._interactions import (  # noqa: F401
-        ApplicationCommandPermissionsData, InteractionData, Locales
+        ApplicationCommandPermissionsData, InteractionData
     )
-    from ._reference import Snowflake
+    from ._reference import Locales, Snowflake
     from ._resources import (  # noqa: F401
         ApplicationData, AutoModerationActionData, AutoModerationRuleData,
         AutoModerationTriggerTypes, CategoryChannelData, EmojiData, GuildData,

--- a/discord_typings/_interactions/_commands.py
+++ b/discord_typings/_interactions/_commands.py
@@ -5,25 +5,15 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 from typing_extensions import Literal, NotRequired, TypedDict, final
 
 if TYPE_CHECKING:
-    from .._reference import Snowflake
+    from .._reference import Locales, Snowflake
     from .._resources import ChannelTypes
 
 __all__ = (
     'ApplicationCommandData', 'ApplicationCommandTypes', 'SubcommandOptionData',
     'SubcommandGroupOptionData', 'AutocompleteOptionData', 'ApplicationCommandOptionData',
     'GuildApplicationCommandPermissionData', 'ApplicationCommandPermissionsData',
-    'ApplicationCommandPayload', 'EditApplicationCommandPermissionsData', 'Locales'
+    'ApplicationCommandPayload', 'EditApplicationCommandPermissionsData'
 )
-
-
-# https://discord.com/developers/docs/reference#locales
-
-
-Locales = Literal[
-    'da', 'de', 'en-GB', 'en-US', 'en-ES', 'fr', 'hr', 'it', 'lt', 'hu', 'nl',
-    'no', 'pl', 'pt-BR', 'ro', 'fi', 'sv-SE', 'vi', 'tr', 'cs', 'el', 'bg',
-    'ru', 'uk', 'hi', 'th', 'zh-CN', 'ja', 'zh-TW', 'ko'
-]
 
 
 # https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
@@ -42,6 +32,7 @@ class ChatInputCommandData(TypedDict):
     options: List[ApplicationCommandOptionData]
     default_member_permissions: NotRequired[Optional[str]]
     dm_permission: NotRequired[bool]
+    nsfw: NotRequired[bool]
     version: Snowflake
 
 
@@ -55,6 +46,7 @@ class ContextMenuCommandData(TypedDict):
     name_localizations: NotRequired[Optional[Dict[Locales, str]]]
     default_member_permissions: NotRequired[Optional[str]]
     dm_permission: NotRequired[bool]
+    nsfw: NotRequired[bool]
     version: Snowflake
 
 
@@ -339,6 +331,7 @@ class ApplicationCommandPayload(TypedDict):
     default_member_permissions: NotRequired[Optional[str]]
     dm_permission: NotRequired[bool]
     type: NotRequired[Literal[1, 2, 3]]
+    nsfw: NotRequired[bool]
 
 
 # https://discord.com/developers/docs/interactions/application-commands#batch-edit-application-command-permissions-example

--- a/discord_typings/_reference.py
+++ b/discord_typings/_reference.py
@@ -4,7 +4,7 @@ from typing_extensions import Literal, TypedDict, final
 
 __all__ = [
     'Snowflake', 'HTTPErrorData', 'InnerHTTPErrorsData', 'NestedHTTPErrorsData',
-    'HTTPErrorResponseData', 'Literal'
+    'HTTPErrorResponseData', 'Locales'
 ]
 
 

--- a/discord_typings/_reference.py
+++ b/discord_typings/_reference.py
@@ -1,10 +1,10 @@
 from typing import Dict, List, Union
 
-from typing_extensions import TypedDict, final
+from typing_extensions import Literal, TypedDict, final
 
 __all__ = [
     'Snowflake', 'HTTPErrorData', 'InnerHTTPErrorsData', 'NestedHTTPErrorsData',
-    'HTTPErrorResponseData',
+    'HTTPErrorResponseData', 'Literal'
 ]
 
 
@@ -42,3 +42,41 @@ class HTTPErrorResponseData(TypedDict):
     code: int
     errors: NestedHTTPErrorsData
     message: str
+
+
+# https://discord.com/developers/docs/reference#locales
+
+
+Locales = Literal[
+    'id',
+    'da',
+    'de',
+    'en-GB',
+    'en-US',
+    'en-ES',
+    'fr',
+    'hr',
+    'it',
+    'lt',
+    'hu',
+    'nl',
+    'no',
+    'pl',
+    'pt-BR',
+    'ro',
+    'fi',
+    'sv-SE',
+    'vi',
+    'tr',
+    'cs',
+    'el',
+    'bg',
+    'ru',
+    'uk',
+    'hi',
+    'th',
+    'zh-CN',
+    'ja',
+    'zh-TW',
+    'ko',
+]

--- a/discord_typings/_resources/__init__.py
+++ b/discord_typings/_resources/__init__.py
@@ -7,6 +7,7 @@ from ._guild import *
 from ._guild_scheduled_events import *
 from ._guild_template import *
 from ._invite import *
+from ._role_connection_metadata import *
 from ._stage_instance import *
 from ._sticker import *
 from ._user import *

--- a/discord_typings/_resources/_application.py
+++ b/discord_typings/_resources/_application.py
@@ -36,6 +36,7 @@ class ApplicationData(TypedDict):
     tags: NotRequired[List[str]]
     install_params: NotRequired[InstallParams]
     custom_install_url: NotRequired[str]
+    role_connections_verification_url: NotRequired[str]
 
 
 # https://discord.com/developers/docs/resources/application#install-params-object-install-params-structure

--- a/discord_typings/_resources/_auto_moderation.py
+++ b/discord_typings/_resources/_auto_moderation.py
@@ -94,6 +94,9 @@ AutoModerationTriggerTypes = Literal[1, 2, 3, 4]
 @final
 class KeywordTriggerMetadataData(TypedDict):
     keyword_filter: List[str]
+    allow_list: List[str]
+
+    regex_patterns: List[str]
 
 
 @final

--- a/discord_typings/_resources/_channel.py
+++ b/discord_typings/_resources/_channel.py
@@ -170,6 +170,7 @@ class ForumChannelData(TypedDict):
     default_reaction_emoji: Optional[DefaultReactionData]
     default_thread_rate_limit_per_user: int
     default_sort_order: Optional[SortOrderTypes]
+    default_forum_layout: ForumLayoutTypes
 
 
 ChannelData = Union[
@@ -194,6 +195,12 @@ VideoQualityModes = Literal[1, 2]
 
 
 SortOrderTypes = Literal[0, 1]
+
+
+# https://discord.com/developers/docs/resources/channel#channel-object-forum-layout-types
+
+
+ForumLayoutTypes = Literal[0, 1, 2]
 
 
 # https://discord.com/developers/docs/resources/channel#message-object-message-structure

--- a/discord_typings/_resources/_guild.py
+++ b/discord_typings/_resources/_guild.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING, List, Optional, Union
 from typing_extensions import Literal, NotRequired, TypedDict, final
 
 if TYPE_CHECKING:
-    from .._interactions import Locales
     from .._oauth import OAuth2Scopes
-    from .._reference import Snowflake
+    from .._reference import Locales, Snowflake
     from ._channel import ChannelData, ThreadChannelData, ThreadMemberData
     from ._emoji import EmojiData
     from ._sticker import StickerData
@@ -127,9 +126,11 @@ PremiumTiers = Literal[0, 1, 2, 3]
 GuildFeaturesData = Literal[
     'ANIMATED_BANNER',
     'ANIMATED_ICON',
+    'APPLICATION_COMMAND_PERMISSIONS_V2',
     'AUTO_MODERATION',
     'BANNER',
     'COMMUNITY',
+    'DEVELOPER_SUPPORT_SERVER',
     'DISCOVERABLE',
     'FEATUREABLE',
     'INVITES_DISABLED',
@@ -140,7 +141,6 @@ GuildFeaturesData = Literal[
     'NEWS',
     'PARTNERED',
     'PREVIEW_ENABLED',
-    'PRIVATE_THREADS',
     'ROLE_ICONS',
     'TICKETED_EVENTS_ENABLED',
     'VANITY_URL',

--- a/discord_typings/_resources/_role_connection_metadata.py
+++ b/discord_typings/_resources/_role_connection_metadata.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Optional
+
+from typing_extensions import Literal, NotRequired, TypedDict, final
+
+if TYPE_CHECKING:
+    from .._reference import Locales
+
+__all__ = (
+    'ApplicationRoleConnectionMetadataData',
+    'ApplicationRoleConnectionMetadataTypes',
+)
+
+
+# https://discord.com/developers/docs/resources/application-role-connection-metadata#application-role-connection-metadata-object
+
+
+@final
+class ApplicationRoleConnectionMetadataData(TypedDict):
+    type: ApplicationRoleConnectionMetadataTypes
+    key: str
+    name: str
+    name_localizations: NotRequired[Optional[Dict[Locales, str]]]
+    description: str
+    description_localizations: NotRequired[Optional[Dict[Locales, str]]]
+
+
+# https://discord.com/developers/docs/resources/application-role-connection-metadata#application-role-connection-metadata-object-application-role-connection-metadata-type
+
+
+ApplicationRoleConnectionMetadataTypes = Literal[1, 2, 3, 4, 5, 6, 7, 8]

--- a/discord_typings/_resources/_user.py
+++ b/discord_typings/_resources/_user.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 from typing_extensions import Literal, NotRequired, TypedDict, final
 
-__all__ = ('UserData', 'UserPremiumTypes', 'ConnectionData', 'ConnectionTypes')
+__all__ = (
+    'UserData',
+    'UserPremiumTypes',
+    'ConnectionData',
+    'ConnectionTypes',
+    'ApplicationRoleConnectionData',
+)
 
 if TYPE_CHECKING:
-    from .._interactions import Locales
-    from .._reference import Snowflake
+    from .._reference import Locales, Snowflake
     from ._guild import IntegrationData
 
 # https://discord.com/developers/docs/resources/user#user-object-user-structure
@@ -79,3 +84,13 @@ class ConnectionData(TypedDict):
     show_activity: bool
     two_way_link: bool
     visibility: Literal[0, 1]
+
+
+# https://discord.com/developers/docs/resources/user#application-role-connection-object
+
+
+@final
+class ApplicationRoleConnectionData(TypedDict):
+    platform_name: Optional[str]
+    platform_username: Optional[str]
+    metadata: Dict[str, str]


### PR DESCRIPTION
This pull request updates the library to match docs. The following diff of the docs can be used: [`48d3c2..main`](https://github.com/discord/discord-api-docs/compare/48d3c2d324796d8236355262ace3b22c1d29acb0..2600e3ceea25c5adcaeaa3d309681abdb6be4077) (in reality, this is a permanent link to the most-recent commit as of opening this PR).