### PR TITLE
feat: add allow_list to KeywordPresetAutoModerationTriggerMetadataData

### DIFF
--- a/discord_typings/_resources/_auto_moderation.py
+++ b/discord_typings/_resources/_auto_moderation.py
@@ -89,6 +89,7 @@ class KeywordAutoModerationTriggerMetadata(TypedDict):
 
 class KeywordPresetAutoModerationTriggerMetadataData(TypedDict):
     presets: List['discord_typings.AutoModerationKeywordPresetTypes']
+    allow_list: List[str]
 
 
 class MentionSpamAutoModerationTriggerMetadataData(TypedDict):


### PR DESCRIPTION
[Discord Docs](https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-metadata:~:text=KEYWORD%2C%20KEYWORD_PRESET)