### PR TITLE
Update library after upstream changes

### DIFF
--- a/discord_typings/__init__.py
+++ b/discord_typings/__init__.py
@@ -10,6 +10,7 @@ from ._resources._user import *
 from ._interactions._commands import *
 from ._interactions._components import *
 from ._interactions._receiving import *
+from ._monetization._entitlements import *
 from ._oauth import *
 from ._reference import *
 from ._resources._application import *

--- a/discord_typings/_gateway.py
+++ b/discord_typings/_gateway.py
@@ -60,6 +60,12 @@ __all__ = (
     'ThreadMemberUpdateEvent',
     'ThreadMembersUpdateData',
     'ThreadMembersUpdateEvent',
+    'EntitlementCreateData',
+    'EntitlementCreateEvent',
+    'EntitlementUpdateData',
+    'EntitlementUpdateEvent',
+    'EntitlementDeleteData',
+    'EntitlementDeleteEvent',
     'ChannelPinsUpdateData',
     'ChannelPinsUpdateEvent',
     'GuildCreateData',
@@ -579,6 +585,33 @@ class ThreadMembersUpdateData(TypedDict):
 
 ThreadMembersUpdateEvent = GenericDispatchEvent[
     Literal['THREAD_MEMBERS_UPDATE'], ThreadMembersUpdateData
+]
+
+
+# https://discord.com/developers/docs/topics/gateway-events#entitlement-create
+
+
+EntitlementCreateData: TypeAlias = 'discord_typings.EntitlementData'
+EntitlementCreateEvent = GenericDispatchEvent[
+    Literal['ENTITLEMENT_CREATE'], EntitlementCreateData
+]
+
+
+# https://discord.com/developers/docs/topics/gateway-events#entitlement-update
+
+
+EntitlementUpdateData: TypeAlias = 'discord_typings.EntitlementData'
+EntitlementUpdateEvent = GenericDispatchEvent[
+    Literal['ENTITLEMENT_UPDATE'], EntitlementUpdateData
+]
+
+
+# https://discord.com/developers/docs/topics/gateway-events#entitlement-delete
+
+
+EntitlementDeleteData: TypeAlias = 'discord_typings.EntitlementData'
+EntitlementDeleteEvent = GenericDispatchEvent[
+    Literal['ENTITLEMENT_DELETE'], EntitlementDeleteData
 ]
 
 

--- a/discord_typings/_interactions/_commands.py
+++ b/discord_typings/_interactions/_commands.py
@@ -37,6 +37,8 @@ class _ChatInputCommandData(TypedDict):
     default_member_permissions: Optional[str]
     dm_permission: NotRequired[bool]
     nsfw: NotRequired[bool]
+    integration_types: NotRequired[List['discord_typings.ApplicationIntegrationTypes']]
+    contexts: NotRequired[List['discord_typings.InteractionContextTypes']]
     version: 'discord_typings.Snowflake'
 
 
@@ -52,6 +54,8 @@ class _ContextMenuCommandData(TypedDict):
     default_member_permissions: Optional[str]
     dm_permission: NotRequired[bool]
     nsfw: NotRequired[bool]
+    integration_types: NotRequired[List['discord_typings.ApplicationIntegrationTypes']]
+    contexts: NotRequired[List['discord_typings.InteractionContextTypes']]
     version: 'discord_typings.Snowflake'
 
 
@@ -311,5 +315,7 @@ class ApplicationCommandPayload(TypedDict):
     options: NotRequired[List['discord_typings.ApplicationCommandOptionData']]
     default_member_permissions: NotRequired[Optional[str]]
     dm_permission: NotRequired[Optional[bool]]
+    integration_types: NotRequired[List['discord_typings.ApplicationIntegrationTypes']]
+    contexts: NotRequired[List['discord_typings.InteractionContextTypes']]
     type: NotRequired['discord_typings.ApplicationCommandTypes']
     nsfw: NotRequired[bool]

--- a/discord_typings/_interactions/_components.py
+++ b/discord_typings/_interactions/_components.py
@@ -16,6 +16,8 @@ __all__ = (
     'ChannelSelectMenuComponentData',
     'SelectMenuComponentData',
     'SelectMenuOptionData',
+    'SelectMenuDefaultValueData',
+    'SelectMenuDefaultValueTypes',
     'TextInputComponentData',
     'TextInputStyles',
     'ComponentData',
@@ -88,6 +90,7 @@ class UserSelectMenuComponentData(TypedDict):
     type: Literal[5]
     custom_id: str
     placeholder: NotRequired[str]
+    default_values: NotRequired[List['discord_typings.SelectMenuDefaultValueData']]
     min_values: NotRequired[int]
     max_values: NotRequired[int]
     disabled: NotRequired[bool]
@@ -97,6 +100,7 @@ class RoleSelectMenuComponentData(TypedDict):
     type: Literal[6]
     custom_id: str
     placeholder: NotRequired[str]
+    default_values: NotRequired[List['discord_typings.SelectMenuDefaultValueData']]
     min_values: NotRequired[int]
     max_values: NotRequired[int]
     disabled: NotRequired[bool]
@@ -106,6 +110,7 @@ class MentionableSelectMenuComponentData(TypedDict):
     type: Literal[7]
     custom_id: str
     placeholder: NotRequired[str]
+    default_values: NotRequired[List['discord_typings.SelectMenuDefaultValueData']]
     min_values: NotRequired[int]
     max_values: NotRequired[int]
     disabled: NotRequired[bool]
@@ -116,6 +121,7 @@ class ChannelSelectMenuComponentData(TypedDict):
     custom_id: str
     channel_types: List['discord_typings.ChannelTypes']
     placeholder: NotRequired[str]
+    default_values: NotRequired[List['discord_typings.SelectMenuDefaultValueData']]
     min_values: NotRequired[int]
     max_values: NotRequired[int]
     disabled: NotRequired[bool]
@@ -137,6 +143,17 @@ class SelectMenuOptionData(TypedDict):
     description: NotRequired[str]
     emoji: NotRequired['discord_typings.EmojiData']
     default: NotRequired[bool]
+
+
+# https://discord.com/developers/docs/interactions/message-components#select-menu-object-select-default-value-structure
+
+
+class SelectMenuDefaultValueData(TypedDict):
+    id: 'discord_typings.Snowflake'
+    type: 'discord_typings.SelectMenuDefaultValueTypes'
+
+
+SelectMenuDefaultValueTypes = Literal['user', 'roles', 'channel']
 
 
 # https://discord.com/developers/docs/interactions/message-components#text-inputs-text-input-structure

--- a/discord_typings/_interactions/_receiving.py
+++ b/discord_typings/_interactions/_receiving.py
@@ -65,7 +65,7 @@ class _ApplicationCommandGuildInteractionData(_GuildInteractionData):
 
 class _ComponentGuildInteractionData(_GuildInteractionData):
     type: Literal[3]
-    data: ComponentInteractionDataData
+    data: 'discord_typings.ComponentInteractionDataData'
     message: 'discord_typings.MessageData'
 
 

--- a/discord_typings/_interactions/_receiving.py
+++ b/discord_typings/_interactions/_receiving.py
@@ -56,6 +56,7 @@ class _GuildInteractionData(TypedDict):
     app_permissions: str
     locale: 'discord_typings.Locales'
     guild_locale: 'discord_typings.Locales'
+    entitlements: NotRequired[List['discord_typings.EntitlementData']]
 
 
 class _ApplicationCommandGuildInteractionData(_GuildInteractionData):
@@ -88,6 +89,7 @@ class _ChannelInteractionData(TypedDict):
     token: str
     version: int
     locale: 'discord_typings.Locales'
+    entitlements: NotRequired[List['discord_typings.EntitlementData']]
 
 
 class _ApplicationCommandChannelInteractionData(_ChannelInteractionData):

--- a/discord_typings/_interactions/_receiving.py
+++ b/discord_typings/_interactions/_receiving.py
@@ -323,7 +323,7 @@ class MessageInteractionData(TypedDict):
 
 
 class _InteractionNodataResponseData(TypedDict):
-    type: Literal[1, 5, 6]
+    type: Literal[1, 5, 6, 10]
 
 
 class _InteractionMessageResponseData(TypedDict):
@@ -350,7 +350,7 @@ InteractionResponseData = Union[
 # https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type
 
 
-InteractionCallbackTypes = Literal[1, 4, 5, 6, 7, 8, 9]
+InteractionCallbackTypes = Literal[1, 4, 5, 6, 7, 8, 9, 10]
 
 
 # https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-data-structure

--- a/discord_typings/_interactions/_receiving.py
+++ b/discord_typings/_interactions/_receiving.py
@@ -14,6 +14,8 @@ __all__ = (
     'ModalInteractionData',
     'InteractionData',
     'InteractionType',
+    'InteractionTypes',
+    'InteractionContextTypes',
     'ApplicationCommandInteractionDataData',
     'ComponentInteractionDataData',
     'ModalSubmitInteractionDataData',
@@ -57,6 +59,11 @@ class _GuildInteractionData(TypedDict):
     locale: 'discord_typings.Locales'
     guild_locale: 'discord_typings.Locales'
     entitlements: NotRequired[List['discord_typings.EntitlementData']]
+    authorizing_integration_owners: Dict[
+        'discord_typings.ApplicationIntegrationTypes',
+        'discord_typings.Snowflake'
+    ]
+    context: Literal[0]
 
 
 class _ApplicationCommandGuildInteractionData(_GuildInteractionData):
@@ -90,6 +97,11 @@ class _ChannelInteractionData(TypedDict):
     version: int
     locale: 'discord_typings.Locales'
     entitlements: NotRequired[List['discord_typings.EntitlementData']]
+    authorizing_integration_owners: Dict[
+        'discord_typings.ApplicationIntegrationTypes',
+        'discord_typings.Snowflake'
+    ]
+    context: Literal[1, 2]
 
 
 class _ApplicationCommandChannelInteractionData(_ChannelInteractionData):
@@ -143,6 +155,13 @@ InteractionData = Union[
 
 
 InteractionType = Literal[1, 2, 3, 4, 5]
+InteractionTypes = InteractionType  # Alias
+
+
+# https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-context-types
+
+
+InteractionContextTypes = Literal[0, 1, 2]
 
 
 # https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-application-command-data-structure

--- a/discord_typings/_monetization/_entitlements.py
+++ b/discord_typings/_monetization/_entitlements.py
@@ -1,0 +1,29 @@
+from typing_extensions import Literal, NotRequired, TypedDict
+
+import discord_typings
+
+__all__ = (
+    'EntitlementData',
+    'EntitlementTypes',
+)
+
+
+# https://discord.com/developers/docs/monetization/entitlements#entitlement-object
+
+
+class EntitlementData(TypedDict):
+    id: 'discord_typings.Snowflake'
+    sku_id: 'discord_typings.Snowflake'
+    application_id: 'discord_typings.Snowflake'
+    user_id: NotRequired['discord_typings.Snowflake']
+    type: 'discord_typings.EntitlementTypes'
+    deleted: bool
+    starts_at: NotRequired[str]
+    ends_at: NotRequired[str]
+    guild_id: NotRequired['discord_typings.Snowflake']
+
+
+# https://discord.com/developers/docs/monetization/entitlements#entitlement-object-entitlement-types
+
+
+EntitlementTypes = Literal[8]

--- a/discord_typings/_reference.py
+++ b/discord_typings/_reference.py
@@ -55,6 +55,7 @@ Locales = Literal[
     'en-GB',
     'en-US',
     'en-ES',
+    'es-419',
     'fr',
     'hr',
     'it',

--- a/discord_typings/_resources/_application.py
+++ b/discord_typings/_resources/_application.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -6,6 +6,8 @@ import discord_typings
 
 __all__ = (
     'ApplicationData',
+    'ApplicationIntegrationTypes',
+    'ApplicationIntegrationTypeConfigurationData',
     'InstallParams',
     'TeamMemberRoleTypes',
     'TeamData',
@@ -36,10 +38,32 @@ class ApplicationData(TypedDict):
     cover_image: NotRequired[str]
     flags: NotRequired[int]
     approximate_guild_count: NotRequired[int]
+    redirect_urls: NotRequired[List[str]]
+    interactions_endpoint_url: NotRequired[str]
+    role_connections_verification_url: NotRequired[str]
     tags: NotRequired[List[str]]
     install_params: NotRequired['discord_typings.InstallParams']
+    integration_types_config: Dict[
+        'discord_typings.ApplicationIntegrationTypes',
+        'discord_typings.ApplicationIntegrationTypeConfigurationData'
+    ]
     custom_install_url: NotRequired[str]
-    role_connections_verification_url: NotRequired[str]
+
+
+# https://discord.com/developers/docs/resources/application#application-object-application-integration-types
+
+
+ApplicationIntegrationTypes = Literal[
+    0,
+    1,
+]
+
+
+# https://discord.com/developers/docs/resources/application#application-object-application-integration-type-configuration-object
+
+
+class ApplicationIntegrationTypeConfigurationData(TypedDict):
+    oauth2_install_params: 'discord_typings.InstallParams'
 
 
 # https://discord.com/developers/docs/resources/application#install-params-object-install-params-structure

--- a/discord_typings/_resources/_channel.py
+++ b/discord_typings/_resources/_channel.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -25,6 +25,7 @@ __all__ = (
     'MessageTypes',
     'MessageActivityData',
     'MessageActivityTypes',
+    'MessageInteractionMetadataData',
     'MessageReferenceData',
     'FollowedChannelData',
     'MessageReactionData',
@@ -264,12 +265,14 @@ class _ChannelMessageData(TypedDict):
     message_reference: NotRequired['discord_typings.MessageReferenceData']
     flags: NotRequired[int]
     referenced_message: NotRequired[Optional['discord_typings.MessageData']]
+    interaction_metadata: NotRequired['discord_typings.MessageInteractionMetadataData']
     interaction: NotRequired['discord_typings.MessageInteractionData']
     thread: NotRequired['discord_typings.ThreadChannelData']
     components: NotRequired[List['discord_typings.ComponentData']]
     sticker_items: NotRequired[List['discord_typings.StickerItemData']]
     position: NotRequired[int]
     role_subscription_data: NotRequired['discord_typings.RoleSubscriptionData']
+    resolved: NotRequired['discord_typings.ResolvedInteractionDataData']
 
 
 class _GuildMessageData(_ChannelMessageData):
@@ -305,6 +308,22 @@ class MessageActivityData(TypedDict):
 
 
 MessageActivityTypes = Literal[1, 2, 3, 5]
+
+
+# https://discord.com/developers/docs/resources/channel#message-interaction-metadata-object
+
+
+class MessageInteractionMetadataData(TypedDict):
+    id: 'discord_typings.Snowflake'
+    type: 'discord_typings.InteractionTypes'
+    user_id: 'discord_typings.Snowflake'
+    authorizing_integration_owners: Dict[
+        'discord_typings.ApplicationIntegrationTypes',
+        'discord_typings.Snowflake'
+    ]
+    original_response_message_id: NotRequired['discord_typings.Snowflake']
+    interacted_message_id: NotRequired['discord_typings.Snowflake']
+    triggering_interaction_metadata: NotRequired['MessageInteractionMetadataData']
 
 
 # https://discord.com/developers/docs/resources/channel#message-reference-object-message-reference-structure

--- a/discord_typings/_resources/_guild.py
+++ b/discord_typings/_resources/_guild.py
@@ -356,7 +356,10 @@ class GuildOnboardingPromptOptionData(TypedDict):
     id: 'discord_typings.Snowflake'
     channel_ids: List['discord_typings.Snowflake']
     role_ids: List['discord_typings.Snowflake']
-    emoji: 'discord_typings.EmojiData'
+    emoji: NotRequired['discord_typings.EmojiData']
+    emoji_id: NotRequired['discord_typings.Snowflake']
+    emoji_name: NotRequired[str]
+    emoji_animated: NotRequired[bool]
     title: str
     description: Optional[str]
 


### PR DESCRIPTION
I went through all changes since the library was last checked for conformity (see [Comparing changes](https://github.com/discord/discord-api-docs/compare/4780bd46d44783e97e399eb80f10aaedc8782339..main)).

It should now be up-to-date for commit 6326e4144ed095c6938ec97e83fa4a58b4f41625, see https://github.com/discord/discord-api-docs/compare/6326e4144ed095c6938ec97e83fa4a58b4f41625..main.