### PR TITLE
Add support for bulk bans

### DIFF
--- a/discord_typings/_resources/_guild.py
+++ b/discord_typings/_resources/_guild.py
@@ -35,6 +35,7 @@ __all__ = (
     'GuildOnboardingPromptTypes',
     'ChannelPositionData',
     'ListThreadsData',
+    'BulkBanData',
     'RolePositionData',
     'RoleData',
     'RoleTagsData',
@@ -392,6 +393,14 @@ class ChannelPositionData(TypedDict):
 class ListThreadsData(TypedDict):
     threads: List['discord_typings.ThreadChannelData']
     members: List['discord_typings.ThreadMemberData']
+
+
+# https://discord.com/developers/docs/resources/guild#bulk-guild-ban-bulk-ban-response
+
+
+class BulkBanData(TypedDict):
+    banned_users: List['discord_typings.Snowflake']
+    failed_users: List['discord_typings.Snowflake']
 
 
 # https://discord.com/developers/docs/resources/guild#modify-guild-role-positions-json-params


### PR DESCRIPTION
This pull request adds support for the response sent by the new bulk ban endpoint: https://github.com/discord/discord-api-docs/pull/6720

@silasary, @plun1331, @EmreTech: I was a bit uncertain of whether to go with `BulkBanResponseData` or `BulkBanData` - anyone have any preferences? I ultimately went with `BulkBanData` for its simplicity, but the name in the docs is `Bulk Ban Response`.

For v1.0, I want to normalize the naming of all payloads to strictly follow the docs' name suffixed with `Data` `Event`, `Command`, or `Payload` (for the special cases). This mostly applies to creative liberties I took with the naming of select menu data, however, I think this pull request could set a good precedent for that implementation in other rare cases (like active threads and channel position data).