### PR TITLE
Add banner to guild member

### DIFF
--- a/discord_typings/_gateway.py
+++ b/discord_typings/_gateway.py
@@ -748,6 +748,7 @@ class GuildMemberAddData(TypedDict):
     user: 'discord_typings.UserData'  # Always present in GUILD_MEMBER_ADD events
     nick: NotRequired[Optional[str]]
     avatar: NotRequired[Optional[str]]
+    banner: NotRequired[Optional[str]]
     roles: List['discord_typings.Snowflake']
     joined_at: str
     premium_since: NotRequired[Optional[str]]
@@ -787,6 +788,7 @@ class GuildMemberUpdateData(TypedDict):
     user: 'discord_typings.UserData'
     nick: NotRequired[Optional[str]]
     avatar: Optional[str]
+    banner: Optional[str]
     joined_at: Optional[str]
     premium_since: NotRequired[Optional[str]]
     deaf: NotRequired[bool]

--- a/discord_typings/_resources/_guild.py
+++ b/discord_typings/_resources/_guild.py
@@ -227,6 +227,7 @@ class GuildMemberData(TypedDict):
     user: NotRequired['discord_typings.UserData']
     nick: NotRequired[Optional[str]]
     avatar: NotRequired[Optional[str]]
+    banner: NotRequired[Optional[str]]
     roles: List['discord_typings.Snowflake']
     joined_at: str
     premium_since: NotRequired[Optional[str]]


### PR DESCRIPTION
Discord has added the not-required, nullable field `banner` to the [Guild Member](https://discord.com/developers/docs/resources/guild#guild-member-object-guild-member-structure) object, making it fetchable ([changelog entry 2024-07-16 here](https://discord.com/developers/docs/change-log#guild-member-banners)). This pull request adds the field to relevant objects.

## Changes
* Add `banner` to `GuildMemberData`, `GuildMemberAddData`, and `GuildMemberUpdateData`